### PR TITLE
Update aboutdialog.ui

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,7 @@ Copyright (c) 2009-2014 Bitcoin Developers
 Copyright (c) 2011-2012 PPCoin Developers
 Copyright (c) 2013 NovaCoin Developers
 Copyright (c) 2014 Blackcoin Developers
-Copyright (c) 2014 Ringo Developers
+Copyright (c) 2014-2018 Ringo Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Copyright (c) 2013 NovaCoin Developers
 
 Copyright (c) 2014 Blackcoin Developers
 
-Copyright (c) 2014 Ringo Developers
+Copyright (c) 2014-2018 Ringo Developers
 
 What is Ringo?
 ----------------

--- a/doc/README
+++ b/doc/README
@@ -2,6 +2,7 @@ Ringo 0.4.4 BETA
 
 Copyright (c) 2013 NovaCoin Developers
 Copyright (c) 2011-2012 PPCoin Developers
+Copyright (c) 2014-2018 Ringo Developers
 Distributed under the MIT/X11 software license, see the accompanying
 file license.txt or http://www.opensource.org/licenses/mit-license.php.
 This product includes software developed by the OpenSSL Project for use in

--- a/doc/README.md
+++ b/doc/README.md
@@ -11,7 +11,7 @@ Copyright (c) 2013 NovaCoin Developers
 
 Copyright (c) 2014 Blackcoin Developers
 
-Copyright (c) 2014 Ringo Developers
+Copyright (c) 2014-2018 Ringo Developers
 
 What is Ringo?
 ----------------

--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -2,7 +2,7 @@ Ringo 1.0.0.0
 
 Copyright (c) 2013 NovaCoin Developers
 Copyright (c) 2011-2013 PPCoin Developers
-Copyright (c) 2014 Ringo Developers
+Copyright (c) 2014-2018 Ringo Developers
 Distributed under the MIT/X11 software license, see the accompanying
 file license.txt or http://www.opensource.org/licenses/mit-license.php.
 This product includes software developed by the OpenSSL Project for use in

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -92,7 +92,8 @@
        </property>
        <property name="text">
         <string>Copyright © 2009-2014 The Bitcoin developers
-Copyright © 2012-2014 The NovaCoin developers</string>
+Copyright © 2012-2014 The NovaCoin developers
+Copyright © 2014-2018 Ringo Developers</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -93,7 +93,7 @@
        <property name="text">
         <string>Copyright © 2009-2014 The Bitcoin developers
 Copyright © 2012-2014 The NovaCoin developers
-Copyright © 2014-2018 Ringo Developers</string>
+Copyright © 2014-2018 The Ringo Developers</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/res/bitcoin-qt.rc
+++ b/src/qt/res/bitcoin-qt.rc
@@ -22,7 +22,7 @@ BEGIN
             VALUE "FileDescription",    "Ringo-Qt (OSS GUI client for Ringo)"
             VALUE "FileVersion",        VER_FILEVERSION_STR
             VALUE "InternalName",       "ringo-qt"
-            VALUE "LegalCopyright",     "2009-2014 The Bitcoin developers, 2012-2013 The NovaCoin & PPCoin developers, 2014 The Blackcoin & Ringo developers"
+            VALUE "LegalCopyright",     "2009-2014 The Bitcoin developers, 2012-2013 The NovaCoin & PPCoin developers, 2014-2018 The Blackcoin & Ringo developers"
             VALUE "LegalTrademarks1",   "Distributed under the MIT/X11 software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "ringo-qt.exe"
             VALUE "ProductName",        "Ringo-Qt"


### PR DESCRIPTION
Small fix for "about".

「Ringoについて」のダイアログにRingo developersのコピーライトを追加するだけの更新です。
